### PR TITLE
conf.py enable furo theme on readthedocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,12 +130,9 @@ todo_include_todos = False
 import os
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    # import sphinx_rtd_theme
-    # html_theme = 'sphinx_rtd_theme'
-    # html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-    import furo
-    html_theme = 'furo'
+
+import furo
+html_theme = 'furo'
     
 # otherwise, readthedocs.org uses their theme by default, so no need to specify it
 


### PR DESCRIPTION
Minor edit to the ODSC sphinx base conf.py default so that the furo theme works on readthedocs