### PR TITLE
Add GeoJSON transformation script and specification

### DIFF
--- a/docs/reference/publication_formats.md
+++ b/docs/reference/publication_formats.md
@@ -8,7 +8,7 @@
 
 To transform a JSON-format OFDS network to GeoJSON format, you must:
 
-* Create an empty JSON object for the nodes feature collection and set it's `.type` to 'FeatureCollection'.
+* Create an empty JSON object for the nodes feature collection and set its `.type` to 'FeatureCollection'.
 * Create an empty JSON object for the links feature collection and set it's `.type` to 'FeatureCollection'.
 * For each contract in `contracts`, [dereference the phase references](#dereference-a-phase-reference) in `.relatedPhases`.
 * For each node in `nodes`:

--- a/docs/reference/publication_formats.md
+++ b/docs/reference/publication_formats.md
@@ -4,4 +4,53 @@
 
 ## GeoJSON
 
+### Transformation specification
+
+To transform a JSON-format OFDS network to GeoJSON format, you must:
+
+* Create an empty JSON object for the nodes feature collection and set it's `.type` to 'FeatureCollection'.
+* Create an empty JSON object for the links feature collection and set it's `.type` to 'FeatureCollection'.
+* For each contract in `contracts`, [dereference the phase references](#dereference-a-phase-reference) in `.relatedPhases`.
+* For each node in `nodes`:
+    * Convert the node to a GeoJSON feature:
+        * Create an empty JSON object for the feature.
+        * Set the feature's:
+        * `.type` to 'Feature'.
+        * `.geometry` to the node's `.location`, if it exists. Otherwise, set `.geometry` to `Null`.
+        * `.properties` to the properties of the node, excluding `.location`.
+        * [Dereference the organisation references](#dereference-an-organisation-reference) in `.properties.physicalInfrastructureProvider` and `.networkProvider`.
+        * [Dereference the phase reference](#dereference-a-phase-reference) in the feature's `.phase` property.
+        * Set `.properties.network` to the properties of the network, excluding `.nodes`, `.links`, `.phases` and `.organisations`.
+    * Add the feature to the nodes feature collection.
+* For each link in `links`:
+    * Convert the link to a GeoJSON Feature:
+        * Create an empty JSON object for the feature.
+        * Set the feature's:
+        * `.type` to 'Feature'.
+        * `.geometry` to the link's `.route`, if it exists. Otherwise, set `.geometry` to `Null`.
+        * `.properties` to the properties of the link, excluding `.route`.
+        * [Dereference the organisation references](#dereference-an-organisation-reference) in `.properties.physicalInfrastructureProvider` and `.networkProvider`.
+        * [Dereference the phase reference](#dereference-a-phase-reference) in `.properties.phase`.
+        * [Dereference the node ids](#dereference-a-node-id) in `properties.start` and `properties.end`.
+        * Set `.properties.network` to the properties of the network, excluding `.nodes`, `.links`, `.phases` and `.organisations`.
+    * Add the feature to the links feature collection.
+
+#### Common operations
+
+##### Dereference an organisation reference
+
+Get the `Organisation` object in `organisations` whose `.id` is equal to the `.id` of the `OrganizationReference`.
+
+##### Dereference a phase reference
+
+Get the `Phase` object in `phases` whose `.id` is equal to the `id` of the `PhaseReference`.
+
+##### Dereference a node ID
+
+Get the `Node` object in `nodes` whose `.id` is equal to the ID.
+
+### Reference implementation
+
+A reference implementation of the transformation is [available in Python on Github](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/blob/main/manage.py). We strongly encourage any re-implementations to read its commented code, to ensure correctness.
+
 ## CSV

--- a/docs/reference/publication_formats.md
+++ b/docs/reference/publication_formats.md
@@ -9,7 +9,7 @@
 To transform a JSON-format OFDS network to GeoJSON format, you must:
 
 * Create an empty JSON object for the nodes feature collection and set its `.type` to 'FeatureCollection'.
-* Create an empty JSON object for the links feature collection and set it's `.type` to 'FeatureCollection'.
+* Create an empty JSON object for the links feature collection and set its `.type` to 'FeatureCollection'.
 * For each contract in `contracts`, [dereference the phase references](#dereference-a-phase-reference) in `.relatedPhases`.
 * For each node in `nodes`:
     * Convert the node to a GeoJSON feature:

--- a/examples/links.geojson
+++ b/examples/links.geojson
@@ -1,0 +1,297 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": null,
+      "properties": {
+        "id": "in est Lorem",
+        "capacity": 65027666.72739151,
+        "ownership": {
+          "title": "Ownership",
+          "$comment": "Work in progress"
+        },
+        "readyForServiceDate": "2007-07-29",
+        "darkFibre": false,
+        "status": "proposed",
+        "supplier": {
+          "name": "qui",
+          "id": "dolore elit eu sint",
+          "quis559": false
+        },
+        "fibreLength": -7882241.099844724,
+        "capacityDetails": {
+          "title": "Capacity details",
+          "$comment": "Work in progress"
+        },
+        "technologies": [
+          "sunt non occaecat elit enim",
+          "qui reprehenderit sint enim",
+          "amet ut ullamco",
+          "sit aute nisi"
+        ],
+        "end": "Lorem in",
+        "deployment": "belowGround",
+        "country": null,
+        "fibreCount": 61818760,
+        "networkProvider": {
+          "id": "est velit aute nulla",
+          "name": "est id dolor nostrud"
+        },
+        "network": {
+          "identifier": "ullamco eiusmod mollit occaecat in",
+          "language": "ex anim occaecat sed",
+          "contracts": [
+            {
+              "id": "proident",
+              "relatedPhases": [
+                {
+                  "id": "laboris ad id",
+                  "name": "Excepteur quis in qui",
+                  "enim_7": "dolor",
+                  "ut7c": "consequat enim laborum"
+                }
+              ],
+              "title": "eu",
+              "value": {
+                "currency": null,
+                "sint_": 76573854
+              },
+              "documents": [
+                {
+                  "minim_1": "non",
+                  "do_7b4": false
+                },
+                {
+                  "ut6": 5521727.84443976
+                },
+                {
+                  "cillum1": 19961553.435848683
+                },
+                {
+                  "tempore6b": false
+                }
+              ],
+              "type": "ipsum Excepteur",
+              "description": "officia cillum in reprehenderit"
+            }
+          ],
+          "crs": {
+            "name": "urn:ogc:def:crs:OGC::CRS84",
+            "uri": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "name": "minim",
+          "accuracyDetails": "nulla",
+          "collectionDate": "2014-06-22",
+          "accuracy": -8557076.28308025,
+          "publisher": {
+            "id": "sit commodo",
+            "listing.symbol": "aliqua commodo",
+            "role": [
+              "Duis",
+              "quis elit sunt"
+            ],
+            "classification": "tempor",
+            "listing.exchange": null,
+            "logo": "https://TpMgpkwTJwkbQjVIEkPUIYqXKRE.rdvmK54YlyOGJ6-z39Vu+z",
+            "name": "proident reprehenderit cupidatat labore ut",
+            "website": "https://fUjMQRln.iallzj-b81TrBkN31DSC9Vq",
+            "identifier": {
+              "uri": "http://xasIfEgWXaI.hfwKP-c-I45vyMfKZnhcq76Waq9ZlRyPb4,7i-LA5qHsxWfAIzXLPlxUF8JZKzy",
+              "id": "pariatur",
+              "legalName": "in",
+              "Excepteur7": -73661482
+            },
+            "country": null
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": null,
+      "properties": {
+        "id": "dolore",
+        "supplier": {
+          "name": "in",
+          "id": "voluptate nulla sunt irure do",
+          "fugiat0": 30056113.613429964
+        },
+        "transmissionMedium": "microwave",
+        "phase": {
+          "occaecat_f6": true
+        },
+        "network": {
+          "identifier": "ullamco eiusmod mollit occaecat in",
+          "language": "ex anim occaecat sed",
+          "contracts": [
+            {
+              "id": "proident",
+              "relatedPhases": [
+                {
+                  "id": "laboris ad id",
+                  "name": "Excepteur quis in qui",
+                  "enim_7": "dolor",
+                  "ut7c": "consequat enim laborum"
+                }
+              ],
+              "title": "eu",
+              "value": {
+                "currency": null,
+                "sint_": 76573854
+              },
+              "documents": [
+                {
+                  "minim_1": "non",
+                  "do_7b4": false
+                },
+                {
+                  "ut6": 5521727.84443976
+                },
+                {
+                  "cillum1": 19961553.435848683
+                },
+                {
+                  "tempore6b": false
+                }
+              ],
+              "type": "ipsum Excepteur",
+              "description": "officia cillum in reprehenderit"
+            }
+          ],
+          "crs": {
+            "name": "urn:ogc:def:crs:OGC::CRS84",
+            "uri": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "name": "minim",
+          "accuracyDetails": "nulla",
+          "collectionDate": "2014-06-22",
+          "accuracy": -8557076.28308025,
+          "publisher": {
+            "id": "sit commodo",
+            "listing.symbol": "aliqua commodo",
+            "role": [
+              "Duis",
+              "quis elit sunt"
+            ],
+            "classification": "tempor",
+            "listing.exchange": null,
+            "logo": "https://TpMgpkwTJwkbQjVIEkPUIYqXKRE.rdvmK54YlyOGJ6-z39Vu+z",
+            "name": "proident reprehenderit cupidatat labore ut",
+            "website": "https://fUjMQRln.iallzj-b81TrBkN31DSC9Vq",
+            "identifier": {
+              "uri": "http://xasIfEgWXaI.hfwKP-c-I45vyMfKZnhcq76Waq9ZlRyPb4,7i-LA5qHsxWfAIzXLPlxUF8JZKzy",
+              "id": "pariatur",
+              "legalName": "in",
+              "Excepteur7": -73661482
+            },
+            "country": null
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "dolor proident",
+        "coordinates": [
+          [],
+          []
+        ],
+        "Duisd7": "enim officia magna",
+        "nulla_f": 79707577
+      },
+      "properties": {
+        "id": "eiusmod dolor commodo ut",
+        "start": "in elit id eu",
+        "status": "operational",
+        "country": null,
+        "physicalInfrastructureProvider": {
+          "id": "pariatur nulla voluptate sed",
+          "name": "fugiat in"
+        },
+        "technologies": [
+          "quis",
+          "culpa consectetur ullamco officia ipsum",
+          "nisi sed",
+          "in magna consequat laborum dolor",
+          "minim dolor fugiat magna nostrud"
+        ],
+        "supplier": {
+          "name": "voluptate in magna",
+          "dolor5": 87693292.69140774,
+          "nulla_b": "pariatur",
+          "ut_f": -99279607,
+          "cupidatat_e59": 87396229.22938937
+        },
+        "network": {
+          "identifier": "ullamco eiusmod mollit occaecat in",
+          "language": "ex anim occaecat sed",
+          "contracts": [
+            {
+              "id": "proident",
+              "relatedPhases": [
+                {
+                  "id": "laboris ad id",
+                  "name": "Excepteur quis in qui",
+                  "enim_7": "dolor",
+                  "ut7c": "consequat enim laborum"
+                }
+              ],
+              "title": "eu",
+              "value": {
+                "currency": null,
+                "sint_": 76573854
+              },
+              "documents": [
+                {
+                  "minim_1": "non",
+                  "do_7b4": false
+                },
+                {
+                  "ut6": 5521727.84443976
+                },
+                {
+                  "cillum1": 19961553.435848683
+                },
+                {
+                  "tempore6b": false
+                }
+              ],
+              "type": "ipsum Excepteur",
+              "description": "officia cillum in reprehenderit"
+            }
+          ],
+          "crs": {
+            "name": "urn:ogc:def:crs:OGC::CRS84",
+            "uri": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "name": "minim",
+          "accuracyDetails": "nulla",
+          "collectionDate": "2014-06-22",
+          "accuracy": -8557076.28308025,
+          "publisher": {
+            "id": "sit commodo",
+            "listing.symbol": "aliqua commodo",
+            "role": [
+              "Duis",
+              "quis elit sunt"
+            ],
+            "classification": "tempor",
+            "listing.exchange": null,
+            "logo": "https://TpMgpkwTJwkbQjVIEkPUIYqXKRE.rdvmK54YlyOGJ6-z39Vu+z",
+            "name": "proident reprehenderit cupidatat labore ut",
+            "website": "https://fUjMQRln.iallzj-b81TrBkN31DSC9Vq",
+            "identifier": {
+              "uri": "http://xasIfEgWXaI.hfwKP-c-I45vyMfKZnhcq76Waq9ZlRyPb4,7i-LA5qHsxWfAIzXLPlxUF8JZKzy",
+              "id": "pariatur",
+              "legalName": "in",
+              "Excepteur7": -73661482
+            },
+            "country": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/examples/network.json
+++ b/examples/network.json
@@ -1,0 +1,183 @@
+{
+    "identifier": "ullamco eiusmod mollit occaecat in",
+    "language": "ex anim occaecat sed",
+    "contracts": [
+      {
+        "id": "proident",
+        "relatedPhases": [
+          {
+            "id": "laboris ad id",
+            "name": "Excepteur quis in qui",
+            "enim_7": "dolor",
+            "ut7c": "consequat enim laborum"
+          }
+        ],
+        "title": "eu",
+        "value": {
+          "currency": null,
+          "sint_": 76573854
+        },
+        "documents": [
+          {
+            "minim_1": "non",
+            "do_7b4": false
+          },
+          {
+            "ut6": 5521727.84443976
+          },
+          {
+            "cillum1": 19961553.435848683
+          },
+          {
+            "tempore6b": false
+          }
+        ],
+        "type": "ipsum Excepteur",
+        "description": "officia cillum in reprehenderit"
+      }
+    ],
+    "crs": {
+      "name": "urn:ogc:def:crs:OGC::CRS84",
+      "uri": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+    },
+    "organisations": [],
+    "links": [
+      {
+        "id": "in est Lorem",
+        "capacity": 65027666.72739151,
+        "ownership": {
+          "title": "Ownership",
+          "$comment": "Work in progress"
+        },
+        "readyForServiceDate": "2007-07-29",
+        "darkFibre": false,
+        "status": "proposed",
+        "supplier": {
+          "name": "qui",
+          "id": "dolore elit eu sint",
+          "quis559": false
+        },
+        "fibreLength": -7882241.099844724,
+        "capacityDetails": {
+          "title": "Capacity details",
+          "$comment": "Work in progress"
+        },
+        "technologies": [
+          "sunt non occaecat elit enim",
+          "qui reprehenderit sint enim",
+          "amet ut ullamco",
+          "sit aute nisi"
+        ],
+        "end": "Lorem in",
+        "deployment": "belowGround",
+        "country": null,
+        "fibreCount": 61818760,
+        "networkProvider": {
+          "id": "est velit aute nulla",
+          "name": "est id dolor nostrud"
+        }
+      },
+      {
+        "id": "dolore",
+        "supplier": {
+          "name": "in",
+          "id": "voluptate nulla sunt irure do",
+          "fugiat0": 30056113.613429964
+        },
+        "transmissionMedium": "microwave",
+        "phase": {
+          "occaecat_f6": true
+        }
+      },
+      {
+        "id": "eiusmod dolor commodo ut",
+        "start": "in elit id eu",
+        "status": "operational",
+        "route": {
+          "type": "dolor proident",
+          "coordinates": [
+            [],
+            []
+          ],
+          "Duisd7": "enim officia magna",
+          "nulla_f": 79707577
+        },
+        "country": null,
+        "physicalInfrastructureProvider": {
+          "id": "pariatur nulla voluptate sed",
+          "name": "fugiat in"
+        },
+        "technologies": [
+          "quis",
+          "culpa consectetur ullamco officia ipsum",
+          "nisi sed",
+          "in magna consequat laborum dolor",
+          "minim dolor fugiat magna nostrud"
+        ],
+        "supplier": {
+          "name": "voluptate in magna",
+          "dolor5": 87693292.69140774,
+          "nulla_b": "pariatur",
+          "ut_f": -99279607,
+          "cupidatat_e59": 87396229.22938937
+        }
+      }
+    ],
+    "name": "minim",
+    "accuracyDetails": "nulla",
+    "collectionDate": "2014-06-22",
+    "accuracy": -8557076.28308025,
+    "publisher": {
+      "id": "sit commodo",
+      "listing.symbol": "aliqua commodo",
+      "role": [
+        "Duis",
+        "quis elit sunt"
+      ],
+      "classification": "tempor",
+      "listing.exchange": null,
+      "logo": "https://TpMgpkwTJwkbQjVIEkPUIYqXKRE.rdvmK54YlyOGJ6-z39Vu+z",
+      "name": "proident reprehenderit cupidatat labore ut",
+      "website": "https://fUjMQRln.iallzj-b81TrBkN31DSC9Vq",
+      "identifier": {
+        "uri": "http://xasIfEgWXaI.hfwKP-c-I45vyMfKZnhcq76Waq9ZlRyPb4,7i-LA5qHsxWfAIzXLPlxUF8JZKzy",
+        "id": "pariatur",
+        "legalName": "in",
+        "Excepteur7": -73661482
+      },
+      "country": null
+    },
+    "nodes": [
+      {
+        "id": "Excepteur",
+        "accessPoint": true,
+        "rackspace": {
+          "title": "Node rackspace",
+          "$comment": "Work in progress"
+        },
+        "address": {
+          "streetAddress": "et amet dolor",
+          "locality": "ad est elit"
+        },
+        "status": "underConstruction",
+        "phase": {
+          "id": "nisi dolore ad proident officia",
+          "name": "qui esse ut veniam"
+        },
+        "internationalConnections": []
+      },
+      {
+        "id": "adipisicing ut eu",
+        "power": false,
+        "rackspace": {
+          "title": "Node rackspace",
+          "$comment": "Work in progress"
+        },
+        "name": "laboris",
+        "networkProvider": {
+          "id": "veniam",
+          "name": "voluptate"
+        }
+      }
+    ]
+  }

--- a/examples/nodes.geojson
+++ b/examples/nodes.geojson
@@ -1,0 +1,178 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": null,
+      "properties": {
+        "id": "Excepteur",
+        "accessPoint": true,
+        "rackspace": {
+          "title": "Node rackspace",
+          "$comment": "Work in progress"
+        },
+        "address": {
+          "streetAddress": "et amet dolor",
+          "locality": "ad est elit"
+        },
+        "status": "underConstruction",
+        "phase": {
+          "id": "nisi dolore ad proident officia",
+          "name": "qui esse ut veniam"
+        },
+        "internationalConnections": [],
+        "network": {
+          "identifier": "ullamco eiusmod mollit occaecat in",
+          "language": "ex anim occaecat sed",
+          "contracts": [
+            {
+              "id": "proident",
+              "relatedPhases": [
+                {
+                  "id": "laboris ad id",
+                  "name": "Excepteur quis in qui",
+                  "enim_7": "dolor",
+                  "ut7c": "consequat enim laborum"
+                }
+              ],
+              "title": "eu",
+              "value": {
+                "currency": null,
+                "sint_": 76573854
+              },
+              "documents": [
+                {
+                  "minim_1": "non",
+                  "do_7b4": false
+                },
+                {
+                  "ut6": 5521727.84443976
+                },
+                {
+                  "cillum1": 19961553.435848683
+                },
+                {
+                  "tempore6b": false
+                }
+              ],
+              "type": "ipsum Excepteur",
+              "description": "officia cillum in reprehenderit"
+            }
+          ],
+          "crs": {
+            "name": "urn:ogc:def:crs:OGC::CRS84",
+            "uri": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "name": "minim",
+          "accuracyDetails": "nulla",
+          "collectionDate": "2014-06-22",
+          "accuracy": -8557076.28308025,
+          "publisher": {
+            "id": "sit commodo",
+            "listing.symbol": "aliqua commodo",
+            "role": [
+              "Duis",
+              "quis elit sunt"
+            ],
+            "classification": "tempor",
+            "listing.exchange": null,
+            "logo": "https://TpMgpkwTJwkbQjVIEkPUIYqXKRE.rdvmK54YlyOGJ6-z39Vu+z",
+            "name": "proident reprehenderit cupidatat labore ut",
+            "website": "https://fUjMQRln.iallzj-b81TrBkN31DSC9Vq",
+            "identifier": {
+              "uri": "http://xasIfEgWXaI.hfwKP-c-I45vyMfKZnhcq76Waq9ZlRyPb4,7i-LA5qHsxWfAIzXLPlxUF8JZKzy",
+              "id": "pariatur",
+              "legalName": "in",
+              "Excepteur7": -73661482
+            },
+            "country": null
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": null,
+      "properties": {
+        "id": "adipisicing ut eu",
+        "power": false,
+        "rackspace": {
+          "title": "Node rackspace",
+          "$comment": "Work in progress"
+        },
+        "name": "laboris",
+        "networkProvider": {
+          "id": "veniam",
+          "name": "voluptate"
+        },
+        "network": {
+          "identifier": "ullamco eiusmod mollit occaecat in",
+          "language": "ex anim occaecat sed",
+          "contracts": [
+            {
+              "id": "proident",
+              "relatedPhases": [
+                {
+                  "id": "laboris ad id",
+                  "name": "Excepteur quis in qui",
+                  "enim_7": "dolor",
+                  "ut7c": "consequat enim laborum"
+                }
+              ],
+              "title": "eu",
+              "value": {
+                "currency": null,
+                "sint_": 76573854
+              },
+              "documents": [
+                {
+                  "minim_1": "non",
+                  "do_7b4": false
+                },
+                {
+                  "ut6": 5521727.84443976
+                },
+                {
+                  "cillum1": 19961553.435848683
+                },
+                {
+                  "tempore6b": false
+                }
+              ],
+              "type": "ipsum Excepteur",
+              "description": "officia cillum in reprehenderit"
+            }
+          ],
+          "crs": {
+            "name": "urn:ogc:def:crs:OGC::CRS84",
+            "uri": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+          },
+          "name": "minim",
+          "accuracyDetails": "nulla",
+          "collectionDate": "2014-06-22",
+          "accuracy": -8557076.28308025,
+          "publisher": {
+            "id": "sit commodo",
+            "listing.symbol": "aliqua commodo",
+            "role": [
+              "Duis",
+              "quis elit sunt"
+            ],
+            "classification": "tempor",
+            "listing.exchange": null,
+            "logo": "https://TpMgpkwTJwkbQjVIEkPUIYqXKRE.rdvmK54YlyOGJ6-z39Vu+z",
+            "name": "proident reprehenderit cupidatat labore ut",
+            "website": "https://fUjMQRln.iallzj-b81TrBkN31DSC9Vq",
+            "identifier": {
+              "uri": "http://xasIfEgWXaI.hfwKP-c-I45vyMfKZnhcq76Waq9ZlRyPb4,7i-LA5qHsxWfAIzXLPlxUF8JZKzy",
+              "id": "pariatur",
+              "legalName": "in",
+              "Excepteur7": -73661482
+            },
+            "country": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/manage.py
+++ b/manage.py
@@ -46,9 +46,9 @@ def dereference_object(ref, list):
     Return from list the object referenced by ref. Otherwise, return ref.
     """
 
-    if "id" in ref:
+    if "id" in ref: # Can remove, `id` is required
         for item in list:
-            if item.get("id") == ref["id"]:
+            if item.get("id") == ref["id"]: # Can simplify, `id` is required
                 return item
 
     return ref
@@ -84,10 +84,11 @@ def convert_to_feature(object, organisation_references, network, organisations, 
     for endpoint in ["start", "end"]:
         if endpoint in properties:
             for node in nodes:
-                if "id" in node and node["id"] == properties[endpoint]:
+                if "id" in node and node["id"] == properties[endpoint]: # Can simplify, `.id` is required
                     properties["endpoint"] = node
 
     # Embed network-level data
+    # TO-DO: Handle case when publishers add an additional `network` field to `Node` or `Link`.
     feature["properties"]["network"] = network
 
     return feature


### PR DESCRIPTION
Closes https://github.com/Open-Telecoms-Data/open-fibre-data-standard/issues/16, relates to https://github.com/Open-Telecoms-Data/open-fibre-data-standard/issues/15

This PR adds:
* a basic transformation script to convert a JSON-format OFDS network to GeoJSON format. Currently, this is part of `manage.py`. Ultimately, it should be a standalone CLI tool with a Python API that can be integrated into other tools. However, for the Alpha version, I think this is sufficient.
* a [transformation specification](https://open-fibre-data-standard.readthedocs.io/en/geojson/reference/publication_formats.html#transformation-specification) that describes the rules for transforming OFDS data from JSON to GeoJSON format
* example input and output files in `/examples`.

@lgs85 please could you give this all a sense check?

Still to do, and possibly not for this PR:

* [ ] Check and update the transformation script and specification against the final alpha schema
* [ ] Write a script to convert from GeoJSON format to JSON format
* [ ] Author more content for the publication formats reference and guidance