### PR TITLE
Add example data to schema reference

### DIFF
--- a/docs/_static/json-example-format.js
+++ b/docs/_static/json-example-format.js
@@ -1,0 +1,36 @@
+   $( document ).ready(function() {
+         $(".expandjson").each(function(){
+          classList = $(this).attr("class").split(/\s+/);
+          expand = []
+          $.each(classList, function(index, item) {
+            if (item.indexOf('expand') === 0) {
+              expand.push(item.replace('expand-',''))
+            }
+            if (item.indexOf('file') === 0) {
+              filename = item
+            }
+          });
+          jsontext = $(this).text().trim()
+          json = JSON.parse(jsontext)
+          if(json.length) {
+              json = json[0]
+          }
+          $(this).html(renderjson.set_show_to_level(1).set_max_string_length(100).set_default_open(expand)(json))
+          if($(this).siblings(".selection-container").length === 0) { // NEED TO FIX THE CODE HERE. MOVE THINGS INTO THE PARENT CLASS CORRECTLY!
+              id = Math.floor(5 * (Math.random() % 1));
+              $(this).wrap("<div class='selection-container'></div>")
+              $(this).parent().prepend(
+                  $("<select name='select-"+id +"'></select>")
+                  .change(function(){ 
+                       $(this).siblings(".expandjson").hide();
+                       $(this).siblings("."+ $(this).val()).show();
+                   }))
+              $(this).siblings("select").append($("<option></option>").attr("value",filename).text(filename.replace("file-",""))) 
+          } else {   
+              container = $(this).siblings(".selection-container")
+              $(this).detach().appendTo(container)
+              $(this).siblings("select").append($("<option></option>").attr("value",filename).text(filename.replace("file-",""))) 
+              $(this).hide()
+          }
+       });
+   });

--- a/docs/_static/renderjson.css
+++ b/docs/_static/renderjson.css
@@ -1,0 +1,11 @@
+pre.renderjson { overflow: scroll; font-size:smaller; border: 1px solid grey;}
+.renderjson a { text-decoration: none; }
+.renderjson .disclosure { color: crimson; font-size: 150%; }
+.renderjson .syntax { color: grey; }
+.renderjson .string { color: darkred; }
+.renderjson .number { color: darkcyan; }
+.renderjson .boolean { color: blueviolet; }
+.renderjson .key    { color: darkblue; }
+.renderjson .keyword { color: blue; }
+.renderjson .object.syntax { color: lightseagreen; }
+.renderjson .array.syntax  { color: orange; }

--- a/docs/_static/renderjson.js
+++ b/docs/_static/renderjson.js
@@ -1,0 +1,194 @@
+// Copyright © 2013-2014 David Caldwell <david@porkrind.org>
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+// Usage
+// -----
+// The module exports one entry point, the `renderjson()` function. It takes in
+// the JSON you want to render as a single argument and returns an HTML
+// element.
+//
+// Options
+// -------
+// renderjson.set_icons("+", "-")
+//   This Allows you to override the disclosure icons.
+//
+// renderjson.set_show_to_level(level)
+//   Pass the number of levels to expand when rendering. The default is 0, which
+//   starts with everything collapsed. As a special case, if level is the string
+//   "all" then it will start with everything expanded.
+//
+// renderjson.set_max_string_length(length)
+//   Strings will be truncated and made expandable if they are longer than
+//   `length`. As a special case, if `length` is the string "none" then
+//   there will be no truncation. The default is "none".
+//
+// renderjson.set_sort_objects(sort_bool)
+//   Sort objects by key (default: false)
+//
+// Theming
+// -------
+// The HTML output uses a number of classes so that you can theme it the way
+// you'd like:
+//     .disclosure    ("⊕", "⊖")
+//     .syntax        (",", ":", "{", "}", "[", "]")
+//     .string        (includes quotes)
+//     .number
+//     .boolean
+//     .key           (object key)
+//     .keyword       ("null", "undefined")
+//     .object.syntax ("{", "}")
+//     .array.syntax  ("[", "]")
+
+var module;
+(module||{}).exports = renderjson = (function() {
+    var themetext = function(/* [class, text]+ */) {
+        var spans = [];
+        while (arguments.length)
+            spans.push(append(span(Array.prototype.shift.call(arguments)),
+                              text(Array.prototype.shift.call(arguments))));
+        return spans;
+    };
+    var append = function(/* el, ... */) {
+        var el = Array.prototype.shift.call(arguments);
+        for (var a=0; a<arguments.length; a++)
+            if (arguments[a].constructor == Array)
+                append.apply(this, [el].concat(arguments[a]));
+            else
+                el.appendChild(arguments[a]);
+        return el;
+    };
+    var prepend = function(el, child) {
+        el.insertBefore(child, el.firstChild);
+        return el;
+    }
+    var isempty = function(obj) { for (var k in obj) if (obj.hasOwnProperty(k)) return false;
+                                  return true; }
+    var text = function(txt) { return document.createTextNode(txt) };
+    var div = function() { return document.createElement("div") };
+    var span = function(classname) { var s = document.createElement("span");
+                                     if (classname) s.className = classname;
+                                     return s; };
+    var A = function A(txt, classname, callback) { var a = document.createElement("a");
+                                                   if (classname) a.className = classname;
+                                                   a.appendChild(text(txt));
+                                                   a.href = '#';
+                                                   a.onclick = function() { callback(); return false; };
+                                                   return a; };
+
+    function _renderjson(json, indent, dont_indent, show_level, max_string, sort_objects) {
+        var my_indent = dont_indent ? "" : indent;
+        var disclosure = function(open, placeholder, close, type, builder) {
+            var content;
+            var empty = span(type);
+            var show = function() { if (!content) append(empty.parentNode,
+                                                         content = prepend(builder(),
+                                                                           A(renderjson.hide, "disclosure",
+                                                                             function() { content.style.display="none";
+                                                                                          empty.style.display="inline"; } )));
+                                    content.style.display="inline";
+                                    empty.style.display="none"; };
+            append(empty,
+                   A(renderjson.show, "disclosure", show),
+                   themetext(type+ " syntax", open),
+                   A(placeholder, null, show),
+                   themetext(type+ " syntax", close));
+
+            var el = append(span(), text(my_indent.slice(0,-1)), empty);
+            if (show_level > 0)
+                show();
+            return el;
+
+        };
+
+        if (json === null) return themetext(null, my_indent, "keyword", "null");
+        if (json === void 0) return themetext(null, my_indent, "keyword", "undefined");
+
+        if (typeof(json) == "string" && json.length > max_string)
+            return disclosure('"', json.substr(0,max_string)+" ...", '"', "string", function () {
+                return append(span("string"), themetext(null, my_indent, "string", JSON.stringify(json)));
+            });
+
+        if (typeof(json) != "object") // Strings, numbers and bools
+            return themetext(null, my_indent, typeof(json), JSON.stringify(json));
+
+        if (json.constructor == Array) {
+            if (json.length == 0) return themetext(null, my_indent, "array syntax", "[]");
+
+            return disclosure("[", " ... ", "]", "array", function () {
+                var as = append(span("array"), themetext("array syntax", "[", null, "\n"));
+                for (var i=0; i<json.length; i++)
+                    append(as,
+                           _renderjson(json[i], indent+"    ", false, show_level-1, max_string, sort_objects),
+                           i != json.length-1 ? themetext("syntax", ",") : [],
+                           text("\n"));
+                append(as, themetext(null, indent, "array syntax", "]"));
+                return as;
+            });
+        }
+
+        // object
+        if (isempty(json))
+            return themetext(null, my_indent, "object syntax", "{}");
+
+        return disclosure("{", "...", "}", "object", function () {
+            var os = append(span("object"), themetext("object syntax", "{", null, "\n"));
+            for (var k in json) var last = k;
+            var keys = Object.keys(json);
+            if (sort_objects)
+                keys = keys.sort();
+            for (var i in keys) {
+                var k = keys[i];
+                append(os, themetext(null, indent+"    ", "key", '"'+k+'"', "object syntax", ': '),
+                       _renderjson(json[k], indent+"    ", true, ((renderjson.default_open.indexOf(k) > -1) ? show_level + 1 : show_level - 1 ), max_string, sort_objects),
+                       k != last ? themetext("syntax", ",") : [],
+                       text("\n"));
+            }
+            append(os, themetext(null, indent, "object syntax", "}"));
+            return os;
+        });
+    }
+
+    var renderjson = function renderjson(json)
+    {
+        var pre = append(document.createElement("pre"), _renderjson(json, "", false, renderjson.show_to_level, renderjson.max_string_length, renderjson.sort_objects));
+        pre.className = "renderjson";
+        return pre;
+    }
+    renderjson.set_icons = function(show, hide) { renderjson.show = show;
+                                                  renderjson.hide = hide;
+                                                  return renderjson; };
+    renderjson.set_show_to_level = function(level) { renderjson.show_to_level = typeof level == "string" &&
+                                                                                level.toLowerCase() === "all" ? Number.MAX_VALUE
+                                                                                                              : level;
+                                                     return renderjson; };
+    renderjson.set_max_string_length = function(length) { renderjson.max_string_length = typeof length == "string" &&
+                                                                                         length.toLowerCase() === "none" ? Number.MAX_VALUE
+                                                                                                                         : length;
+                                                          return renderjson; };
+    renderjson.set_sort_objects = function(sort_bool) { renderjson.sort_objects = sort_bool;
+                                                        return renderjson; };
+    // Backwards compatiblity. Use set_show_to_level() for new code.
+    renderjson.set_show_by_default = function(show) { renderjson.show_to_level = show ? Number.MAX_VALUE : 0;
+                                                      return renderjson; };
+                                                      
+    //Added by timgdavies
+    renderjson.set_default_open = function(node_list) { renderjson.default_open = node_list ? node_list : [] ; return renderjson; };
+    
+    renderjson.set_icons('⊕', '⊖');
+    renderjson.set_show_by_default(false);
+    renderjson.set_sort_objects(false);
+    renderjson.set_max_string_length("none");
+    renderjson.set_default_open([]);
+    return renderjson;
+})();

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,3 +1,3 @@
 {% extends "!layout.html" %}
-
-{% set css_files = css_files + ["_static/basic.css"] %}
+{% set css_files = css_files + ["_static/renderjson.css"] %}
+{% set script_files = script_files + ["_static/renderjson.js", "_static/json-example-format.js"] %}

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -32,9 +32,24 @@ This section describes the overall structure of the OFDS schema. The top-level o
 
 In addition to the above sections, there are several top-level metadata fields:
 
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :collapse: nodes,links,phases,organisations,contracts,publisher,crs
 ```
+
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer:
+   :title: Example
+```
+:::
+
+::::
 
 #### Nodes
 
@@ -83,11 +98,27 @@ The following issues relate to this component or its fields:
 ```{jsoninclude-quote} ../../schema/network-schema.json
 :jsonpointer: /definitions/Node/description
 ```
+
 Each `Node` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/Node
 :collapse: id,name,phase,status,location,address,type,accessPoint,internationalConnections,power,technologies,physicalInfrastructureProvider,networkProvider
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /nodes
+   :title: Example
+```
+:::
+
+::::
+
 
 #### Link
 ```{admonition} Alpha consultation
@@ -106,10 +137,24 @@ The following issues relate to this component or its fields:
 :jsonpointer: /definitions/Link/description
 ```
 Each `Link` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/Link
 :collapse: id,name,phase,status,readyForServiceDate,start,end,route,physicalInfrastructureProvider,networkProvider,supplier,transmissionMedium,deployment,deploymentDetails,darkFibre,fibreType,fibreTypeDetails,fibreCount,fibreLength,technologies,capacity,capacityDetails,countries,directed
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /links
+```
+:::
+
+::::
+
 
 #### Phase
 `Phase` is defined as:
@@ -117,10 +162,25 @@ Each `Link` has the following fields:
 :jsonpointer: /definitions/Phase/description
 ```
 Each `Phase` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/Phase
 :collapse: id,name,description,funders
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /phases
+   :title: Example
+```
+:::
+
+::::
+
 
 #### Organisation
 ```{admonition} Alpha consultation
@@ -132,10 +192,25 @@ The following issues relate to this component or its fields:
 :jsonpointer: /definitions/Organisation/description
 ```
 Each `Organisation` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/Organisation
 :collapse: id,name,identifier,country,roles,roleDetails,website,logo
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /organisations
+   :title: Example
+```
+:::
+
+::::
+
 
 #### Contract
 ```{admonition} Alpha consultation
@@ -147,10 +222,25 @@ The following issues relate to this component or its fields:
 :jsonpointer: /definitions/Contract/description
 ```
 Each `Contract` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/Contract
 :collapse: id,title,description,type,value,dateSigned,documents,relatedPhases
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /contracts
+   :title: Example
+```
+:::
+
+::::
+
 
 #### Geometry
 `Geometry` is defined as:
@@ -158,10 +248,29 @@ Each `Contract` has the following fields:
 :jsonpointer: /definitions/Geometry/description
 ```
 Each `Geometry` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/Geometry
 :collapse: type,coordinates
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /nodes/0/location
+   :title: Node
+
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /links/0/route
+   :title: Link
+```
+:::
+
+::::
+
 
 #### OrganisationReference
 `OrganisationReference` is defined as:
@@ -169,10 +278,24 @@ Each `Geometry` has the following fields:
 :jsonpointer: /definitions/OrganisationReference/description
 ```
 Each `OrganisationReference` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/OrganisationReference
 :collapse: id,name
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /links/0/physicalInfrastructureProvider
+   :title: Example
+```
+:::
+
+::::
 
 #### PhaseReference
 `PhaseReference` is defined as:
@@ -180,10 +303,25 @@ Each `OrganisationReference` has the following fields:
 :jsonpointer: /definitions/PhaseReference/description
 ```
 Each `PhaseReference` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/PhaseReference
 :collapse: id,name
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /contracts/0/relatedPhases
+   :title: Example
+```
+:::
+
+::::
+
 
 #### Address
 `Address` is defined as:
@@ -191,10 +329,24 @@ Each `PhaseReference` has the following fields:
 :jsonpointer: /definitions/Address/description
 ```
 Each `Address` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/Address
 :collapse: streetAddress,locality,region,postalCode,country
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /nodes/0/address
+   :title: Example
+```
+:::
+
+::::
 
 #### Value
 `Value` is defined as:
@@ -202,10 +354,25 @@ Each `Address` has the following fields:
 :jsonpointer: /definitions/Value/description
 ```
 Each `Value` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/Value
 :collapse: amount,currency
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /contracts/0/value
+   :title: Example
+```
+:::
+
+::::
+
 
 #### Document
 `Document` is defined as:
@@ -213,10 +380,25 @@ Each `Value` has the following fields:
 :jsonpointer: /definitions/Document/description
 ```
 Each `Document` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/Document
 :collapse: title,description,url,format
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /contracts/0/documents
+   :title: Example
+```
+:::
+
+::::
+
 
 #### Identifier
 `Identifier` is defined as:
@@ -224,10 +406,25 @@ Each `Document` has the following fields:
 :jsonpointer: /definitions/Identifier/description
 ```
 Each `Identifier` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/Identifier
 :collapse: id,scheme,legalName,uri
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /organisations/0/identifier
+   :title: Example
+```
+:::
+
+::::
+
 
 #### CoordinateReferenceSystem
 Coordinates in all OFDS data must be specified in the coordinate reference system [required by GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946#section-4):
@@ -252,10 +449,24 @@ The following issues relate to this component or its fields:
 :jsonpointer: /definitions/CoordinateReferenceSystem/description
 ```
 Each `CoordinateReferenceSystem` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/CoordinateReferenceSystem
 :collapse: name,uri
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /crs
+   :title: Example
+```
+:::
+
+::::
 
 #### RelatedResourceReference
 ```{admonition} Alpha consultation
@@ -268,10 +479,29 @@ The following issues relate to this component or its fields:
 :jsonpointer: /definitions/RelatedResourceReference/description
 ```
 Each `RelatedResourceReference` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/RelatedResourceReference
 :collapse: href,rel
 ```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network-separate-endpoints.json
+   :jsonpointer: /relatedResources
+   :title: Pagination
+
+.. jsoninclude:: ../../examples/json/network-separate-files.json
+   :jsonpointer: /relatedResources
+   :title: Streaming
+```
+:::
+
+::::
+
 
 #### FibreTypeDetails
 `FibreTypeDetails` is defined as:
@@ -279,10 +509,26 @@ Each `RelatedResourceReference` has the following fields:
 :jsonpointer: /definitions/FibreTypeDetails/description
 ```
 Each `FibreTypeDetails` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/FibreTypeDetails
 :collapse: description
 ```
+```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /links/0/fibreTypeDetails
+   :title: Example
+```
+:::
+
+::::
+
 
 #### DeploymentDetails
 ```{admonition} Alpha consultation
@@ -294,10 +540,26 @@ The following issues relate to this component or its fields:
 :jsonpointer: /definitions/DeploymentDetails/description
 ```
 Each `DeploymentDetails` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/DeploymentDetails
 :collapse: description
 ```
+```
+:::
+
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /links/0/deploymentDetails
+   :title: Example
+```
+:::
+
+::::
+
 
 #### CapacityDetails
 ```{admonition} Alpha consultation
@@ -309,8 +571,21 @@ The following issues relate to this component or its fields:
 :jsonpointer: /definitions/CapacityDetails/description
 ```
 Each `CapacityDetails` has the following fields:
+::::{tab-set}
+
+:::{tab-item} Schema
 ```{jsonschema} ../../schema/network-schema.json
 :pointer: /definitions/CapacityDetails
 :collapse: description
 ```
+:::
 
+:::{tab-item} Example
+```{eval-rst} 
+.. jsoninclude:: ../../examples/json/network.json
+   :jsonpointer: /links/0/capacityDetails
+   :title: Example
+```
+:::
+
+::::


### PR DESCRIPTION
Related to #57 

This PR adds example data to each component in the schema reference. Note that to enable the full functionality of `jsoninclude` directives I've added javascript and css files as recommended in the [documentation](https://sphinxcontrib-opendataservices.readthedocs.io/en/latest/jsoninclude/#jsoninclude-javascript). This will result in a change to the rendering of other examples throughout the reference and guidance, and I suggest we check and fix this as part of an overall check.

[Preview](https://open-fibre-data-standard.readthedocs.io/en/reference_examples/reference/schema.html)