### PR TITLE
add watch dirs to autobuild

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -226,6 +226,6 @@ dummy:
 
 .PHONY: autobuild
 autobuild:
-	sphinx-autobuild -nW -q -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	sphinx-autobuild -E --watch ../examples --watch ../schema --watch ../_assets --watch ../codelists -nW -q -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Auto-build finished. The HTML pages are in $(BUILDDIR)/dirhtml."


### PR DESCRIPTION
Closes #21 

@duncandewhurst I'm in two minds about this. The only way I could get this to work was to add the `-E` argument to [sphinx-autobuild](https://github.com/executablebooks/sphinx-autobuild) which slows things down considerably.  Have a play and see what you think, but unless there's another solution I'd be minded to not implement this in favour of a faster build and needing to make dummy edits to the docs files when making changes to the schema and examples.