### PR TITLE
schema/network-schema.json: Fix link to referenceRelationType codelist

### DIFF
--- a/schema/network-schema.json
+++ b/schema/network-schema.json
@@ -2045,7 +2045,7 @@
         },
         "rel": {
           "title": "Reference relation type",
-          "description": "The relationship with this related resource, from the open [referenceRelationType codelist](https://open-fibre-data-standard.readthedocs.io/en/latest/reference/codelists.html#referenceRelationType).",
+          "description": "The relationship with this related resource, from the open [referenceRelationType codelist](https://open-fibre-data-standard.readthedocs.io/en/latest/reference/codelists.html#referencerelationtype).",
           "type": "string",
           "$comment": "",
           "codelist": "referenceRelationType.csv",


### PR DESCRIPTION
Related to #128 

Noting that I've made this change directly in `network-schema.json` rather than in Airtable.