### PR TITLE
139 sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,16 +138,19 @@ todo_include_todos = False
 import os
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'furo'
     
 # otherwise, readthedocs.org uses their theme by default, so no need to specify it
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#
-html_theme_options = {'navigation_depth': 5}
 
+html_theme_options = {
+    "light_css_variables": {
+        "color-table-border": "#9d9d9e",
+    },
+}
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
 

--- a/requirements.in
+++ b/requirements.in
@@ -13,3 +13,4 @@ ocdskit
 sphinx-design
 ofdskit
 flattentool
+furo

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ babel==2.10.3
     #   sphinx-intl
 backports-datetime-fromisoformat==1.0.0
     # via flattentool
+beautifulsoup4==4.11.1
+    # via furo
 btrees==4.10.1
     # via zodb
 cattrs==22.1.0
@@ -52,6 +54,8 @@ et-xmlfile==1.1.0
 exceptiongroup==1.0.0rc9
     # via cattrs
 flattentool==0.18.1
+    # via -r requirements.in
+furo==2022.9.29
     # via -r requirements.in
 gitdb==4.0.9
     # via gitpython
@@ -129,7 +133,9 @@ pycparser==2.21
 pygithub==1.55
     # via -r requirements.in
 pygments==2.12.0
-    # via sphinx
+    # via
+    #   furo
+    #   sphinx
 pyjwt==2.4.0
     # via pygithub
 pynacl==1.5.0
@@ -167,17 +173,23 @@ smmap==5.0.0
     # via gitdb
 snowballstemmer==2.2.0
     # via sphinx
+soupsieve==2.3.2.post1
+    # via beautifulsoup4
 sphinx==4.5.0
     # via
     #   -r requirements.in
+    #   furo
     #   myst-parser
     #   sphinx-autobuild
+    #   sphinx-basic-ng
     #   sphinx-design
     #   sphinx-intl
     #   sphinx-rtd-theme
     #   sphinxcontrib-opendataservices
 sphinx-autobuild==2021.3.14
     # via -r requirements.in
+sphinx-basic-ng==1.0.0b1
+    # via furo
 sphinx-design==0.3.0
     # via -r requirements.in
 sphinx-intl==2.0.1


### PR DESCRIPTION
**Related issues**
#139 

**Description**
Preview [here](https://open-fibre-data-standard.readthedocs.io/en/139-sphinx-theme/index.html).

I've changed to furo and left more or less as is for now - just darkened the table borders slightly.

The previous problems with the schema browser appear to be sorted, but I am unsure about how this theme renders tables. The furo theme is [fairly customisable](https://pradyunsg.me/furo/customisation/) but there are no options for things like table font size, subheader colours etc. I suspect this can be done using custom CSS but not sure I have time for that.

Other themes are less customisable still, so in leiu of making our own theme I think there's a question if we we go for this, vs the standard RTD theme.

**Merge checklist**
NA