### PR TITLE
docs/reference/publication_formats: Fix package schema link

### DIFF
--- a/docs/guidance/publication.md
+++ b/docs/guidance/publication.md
@@ -108,7 +108,7 @@ To meet the widest range of use cases, you ought to publish data in all three fo
 :::{tab-item} JSON to GeoJSON
 The command line tool [Lib CoVE OFDS](https://libcoveofds.readthedocs.io/en/latest/) provides an interface for transforming OFDS data from JSON to GeoJSON format.
 
-To convert a network package to GeoJSON format, first install Lib CoVE OFDS by following the [installation instructions](https://github.com/Open-Telecoms-Data/lib-cove-ofds#installation). Then, run the following command:
+To convert a network package to GeoJSON format, install Lib CoVE OFDS and run the following command:
 
 ```bash
 libcoveofds jsontogeojson network-package.json nodes.geojson spans.geojson

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -20,7 +20,8 @@ Iterative improvements are made outside of the release cycle. They do not involv
 - [#201](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/201) - Add support page.
 - [#208](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/208) - Add link to "WGS 84" text in docs/reference/schema.md.
 - [#213](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/213) - For GeoJSON/JSON conversion, use libcoveofds now.
-- [#232](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/232) - Remove unmaintained GitHub issue admonitions
+- [#232](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/232) - Remove unmaintained GitHub issue admonitions.
+- [#245](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/245) - Fix package schema link in 0.2.0 release.
 
 ## 0.2.0 - 2023-01-11
 

--- a/docs/reference/publication_formats/json.md
+++ b/docs/reference/publication_formats/json.md
@@ -18,7 +18,7 @@ For guidance on paginating or streaming individual networks, see [how to publish
 
 The network package schema describes the structure of the container for publishing one or more networks in JSON format and for supporting pagination.
 
-For this version of OFDS, the canonical URL of the schema is [https://raw.githubusercontent.com/Open-Telecoms-Data/open-fibre-data-standard/0\_\_1\_\_0\_\_beta/schema/network-package-schema.json](https://raw.githubusercontent.com/Open-Telecoms-Data/open-fibre-data-standard/0__1__0__beta/schema/network-package-schema.json). Use the canonical URL to make sure that your software, documentation or other resources refer to the specific version of the schema with which they were tested.
+For this version of OFDS, the canonical URL of the schema is [https://raw.githubusercontent.com/Open-Telecoms-Data/open-fibre-data-standard/0\_\_2\_\_0/schema/network-package-schema.json](https://raw.githubusercontent.com/Open-Telecoms-Data/open-fibre-data-standard/0__2__0/schema/network-package-schema.json). Use the canonical URL to make sure that your software, documentation or other resources refer to the specific version of the schema with which they were tested.
 
 This page presents the schema in an interactive browser. You can also download the canonical version of the schema as [JSON Schema](../../../schema/network-package-schema.json).
 


### PR DESCRIPTION
**Related issues**

See https://github.com/Open-Telecoms-Data/standard-development-handbook/pull/25#issuecomment-1381029034

**Description**

This PR fixes the link to the package schema on https://open-fibre-data-standard.readthedocs.io/en/latest/reference/publication_formats/json.html#small-files-and-api-responses-option and the link to the Lib Cove OFDS docs on https://open-fibre-data-standard.readthedocs.io/en/latest/guidance/publication.html#how-to-format-data-for-publication.

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog ([style guide](https://ofds-standard-development-handbook.readthedocs.io/en/latest/style/changelog_style_guide.html))
- [ ] Run `./manage.py pre-commit` to update derivative schema files, reference documentation and examples

If there are changes to `network-schema.json`, `network-package-schema.json`, `reference/publication_formats/json.md`, `reference/publication_formats/geojson.md` or `guidance/publication.md#how-to-publish-large-networks`, update the relevant manually authored examples:

- [ ] `examples/json/`:
  - [ ] `network-package.json`
  - [ ] `api-response.json`
  - [ ] `multiple-networks.json`
  - [ ] `network-embedded.json`
  - [ ] `network-separate-endpoints.json`
  - [ ] `network-separate-files.json`
  - [ ] `nodes-endpoint.json`
  - [ ] `spans-endpoint.json`
- [ ] `examples/geojson/`:
  - [ ] `api-response.geojson`
  - [ ] `multiple-networks.geojson`

If you used a validation keyword, type or format that is not [already used in the schema](https://ofds-standard-development-handbook.readthedocs.io/en/latest/standard/schema.html#json-schema-usage):

- [ ] Update the list of validation keywords, types or formats in [JSON Schema usage](https://ofds-standard-development-handbook.readthedocs.io/en/latest/standard/schema.html#json-schema-usage).
- [ ] Add a field that fails validation against the new keyword, type or format to [`network-package-invalid.json`](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/blob/0.1-dev/examples/json/network-package-invalid.json).
- [ ] Check that [OFDS CoVE](https://ofds.cove.opendataservices.coop/) reports an appropriate validation error.

If you added a normative rule that is not encoded in JSON Schema:

- [ ] Update the list of [other normative rules](https://ofds-standard-development-handbook.readthedocs.io/en/latest/standard/schema.html#other-normative-rules).
- [ ] Add a field that does not conform to the rule to [`network-package-additional-checks.json`](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/blob/0.1-dev/examples/json/network-package-additional-checks.json).
- [ ] Open a [new issue](https://github.com/Open-Telecoms-Data/lib-cove-ofds/issues/new/choose) to add an additional check to Lib Cove OFDS.

If there are changes to `examples/geojson/nodes.geojson` or `examples/geojson/spans.geojson`, check and update the data use examples:

- [ ] `examples/leaflet/leaflet.ipynb`
- [ ] `examples/qgis/geojson.qgs`
