### PR TITLE
docs/reference/schema.md: Expand publisher object in schema table

### DIFF
--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -28,7 +28,7 @@ Iterative improvements are made outside of the release cycle. They do not involv
 
 - [#258](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/258) - Add unit to `Span.fibreLength` description
 - [#260](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/260) - Replace `id` with `$id` and `definitions` with `$defs` in schema files.
-- [#261](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/261) - Replace `publisher` with an object.
+- [#261](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/261), [#270](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/270) - Replace `publisher` with an object.
 
 ### Codelists
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -45,7 +45,7 @@ In addition to the above sections, there are several top-level metadata fields:
 :::{tab-item} Schema
 
 ```{jsonschema} ../../schema/network-schema.json
-:collapse: nodes,spans,phases,organisations,contracts,publisher,crs,links
+:collapse: nodes,spans,phases,organisations,contracts,crs,links
 :addtargets:
 ```
 


### PR DESCRIPTION
**Related issues**

#190

**Description**

This PR expands the `publisher` object in the schema reference table. It should have been done as part of #261 

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog ([style guide](https://ofds-standard-development-handbook.readthedocs.io/en/latest/style/changelog_style_guide.html))
- [ ] Run `./manage.py pre-commit` to update derivative schema files, reference documentation and examples

If there are changes to `network-schema.json`, `network-package-schema.json`, `reference/publication_formats/json.md`, `reference/publication_formats/geojson.md` or `guidance/publication.md#how-to-publish-large-networks`, update the relevant manually authored examples:

- [ ] `examples/json/`:
  - [ ] `network-package.json`
  - [ ] `api-response.json`
  - [ ] `multiple-networks.json`
  - [ ] `network-embedded.json`
  - [ ] `network-separate-endpoints.json`
  - [ ] `network-separate-files.json`
  - [ ] `nodes-endpoint.json`
  - [ ] `spans-endpoint.json`
- [ ] `examples/geojson/`:
  - [ ] `api-response.geojson`
  - [ ] `multiple-networks.geojson`

If you used a validation keyword, type or format that is not [already used in the schema](https://ofds-standard-development-handbook.readthedocs.io/en/latest/standard/schema.html#json-schema-usage):

- [ ] Update the list of validation keywords, types or formats in [JSON Schema usage](https://ofds-standard-development-handbook.readthedocs.io/en/latest/standard/schema.html#json-schema-usage).
- [ ] Add a field that fails validation against the new keyword, type or format to [`network-package-invalid.json`](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/blob/0.1-dev/examples/json/network-package-invalid.json).
- [ ] Check that [OFDS CoVE](https://ofds.cove.opendataservices.coop/) reports an appropriate validation error.

If you added a normative rule that is not encoded in JSON Schema:

- [ ] Update the list of [other normative rules](https://ofds-standard-development-handbook.readthedocs.io/en/latest/standard/schema.html#other-normative-rules).
- [ ] Add a field that does not conform to the rule to [`network-package-additional-checks.json`](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/blob/0.1-dev/examples/json/network-package-additional-checks.json).
- [ ] Open a [new issue](https://github.com/Open-Telecoms-Data/lib-cove-ofds/issues/new/choose) to add an additional check to Lib Cove OFDS.

If there are changes to `examples/geojson/nodes.geojson` or `examples/geojson/spans.geojson`, check and update the data use examples:

- [ ] `examples/leaflet/leaflet.ipynb`
- [ ] `examples/qgis/geojson.qgs`
