### PR TITLE
schema/network-schema.json: Disallow additional properties in Geometry

### DIFF
--- a/docs/guidance/publication.md
+++ b/docs/guidance/publication.md
@@ -102,7 +102,7 @@ If you’re concerned about disclosing the exact location of fibre infrastructur
 
 ### How to add additional fields
 
-The OFDS schema does not restrict the use of additional fields. If there is a data element that you wish to publish for which you cannot identify a suitable mapping in OFDS, you can add an additional field to your data.
+The OFDS schema does not restrict the use of additional fields, except where noted in the [schema reference](../reference/schema.md). If there is a data element that you wish to publish for which you cannot identify a suitable mapping in OFDS, you can add an additional field to your data.
 
 Before adding an additional field, you ought to search the [standard issue tracker](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/issues) to see if a similar concept has already been discussed. If there are no existing discussions, you ought to open a new issue and describe the concept that you want to publish and your proposed modelling.
 

--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -29,6 +29,7 @@ Iterative improvements are made outside of the release cycle. They do not involv
 - [#258](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/258) - Add unit to `Span.fibreLength` description.
 - [#260](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/260) - Replace `id` with `$id` and `definitions` with `$defs` in schema files.
 - [#261](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/261), [#270](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/270) - Replace `publisher` with an object.
+- [#274](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/274) - Disallow additional properties in `Geometry` objects.
 
 ### Codelists
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -300,6 +300,8 @@ This component is referenced by the following properties:
 - [`Node/location`](network-schema.json,/$defs/Node,location)
 - [`Span/route`](network-schema.json,/$defs/Span,route)
 
+Additional properties are not permitted within `Geometry` objects.
+
 Each `Geometry` has the following fields:
 
 ::::{tab-set}

--- a/manage.py
+++ b/manage.py
@@ -455,6 +455,9 @@ def update_schema_docs(schema):
           url += ','.join(ref)
           definition["content"].append(f"- [`{'/'.join(ref)}`]({url})\n")
 
+      if definition.get('additionalProperties') == False:
+         definition["content"].append(f"\nAdditional properties are not permitted within `{defn}` objects.\n")
+
       # Add schema table
       definition["content"].extend([
           f"\nEach `{defn}` has the following fields:\n\n", 

--- a/schema/network-schema.json
+++ b/schema/network-schema.json
@@ -1218,9 +1218,7 @@
         "coordinates"
       ],
       "minProperties": 1,
-      "propertyNames": {
-        "pattern": "^(?!(properties$|^features$))"
-      }
+      "additionalProperties": false
     },
     "OrganisationReference": {
       "title": "Organisation reference",


### PR DESCRIPTION
**Related issues**

* #10 

**Description**

This PR relates to an issue that surfaced whilst updating tooling for version 0.3:

Following #262, WKT is used to represent `Geometry` objects in the CSV publication format. WKT does not support additional properties so in order to prevent undefined behaviour and to support roundtripping without data loss, we need to disallow additional properties in the `Geometry` object. Certain property names (`properties` and `features`) were already prohibited, per the GeoJSON specification. Given that there are not yet any implementations and given that we've heard no demand for additional properties within `Geometry` objects, I think this change is fine to make.

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog ([style guide](https://ofds-standard-development-handbook.readthedocs.io/en/latest/style/changelog_style_guide.html))
- [x] Run `./manage.py pre-commit` to update derivative schema files, reference documentation and examples

If you used a validation keyword, type or format that is not [already used in the schema](https://ofds-standard-development-handbook.readthedocs.io/en/latest/standard/schema.html#json-schema-usage):

- [x] Update the list of validation keywords, types or formats in [JSON Schema usage](https://ofds-standard-development-handbook.readthedocs.io/en/latest/standard/schema.html#json-schema-usage).
- [ ] ~~Add a field that fails validation against the new keyword, type or format to [`network-package-invalid.json`](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/blob/0.1-dev/examples/json/network-package-invalid.json).~~ (existing file is sufficient)
- [ ] Check that [OFDS CoVE](https://ofds.cove.opendataservices.coop/) reports an appropriate validation error.
