### PR TITLE
docs/Makefile (autobuild): Watch changes outside docs directory

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -226,6 +226,6 @@ dummy:
 
 .PHONY: autobuild
 autobuild:
-	sphinx-autobuild -nW -q -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
+	sphinx-autobuild -nW -q -b dirhtml --watch ../ $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Auto-build finished. The HTML pages are in $(BUILDDIR)/dirhtml."


### PR DESCRIPTION
**Related issues**

* Closes #21

No changelog entry needed.