### PR TITLE
docs/reference/data_formats/json/network_schema.md: Update text

### DIFF
--- a/docs/history/changelog.md
+++ b/docs/history/changelog.md
@@ -42,7 +42,7 @@ Iterative improvements are made outside of the release cycle. They do not involv
     - Remove `Span.deploymentDetails.description`, in favour of `Span.supportingInfrastructure.description`.
     - Move codes relating to supporting infrastructure from the nodeType codelist to the nodeSupportingInfrastructureType codelist
 - [#321](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/321) - Add `Span.cableType` and `Span.codeployment`
-- [#328](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/328) - Disallow properties named `network` in `Span` and `Node` definitions, and additional properties in `OrganisationReference` and `PhaseReference` definitions, to ease conversion between formats.
+- [#328](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/328), [#339](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/339) - Disallow properties named `network` in `Span` and `Node` definitions, and additional properties in `OrganisationReference` and `PhaseReference` definitions, to ease conversion between formats.
 - [#327](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/327) - Improve validation of GeoJSON geometry objects
 - [#322](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/322) - Update `Node.type` description to explain modelling of junctions
 - [#329](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/pull/329) - Add `Network.id`, recommend unique names for nodes, spans, phases and organisations

--- a/docs/reference/data_formats/json/network_schema.md
+++ b/docs/reference/data_formats/json/network_schema.md
@@ -407,6 +407,8 @@ This sub-schema is referenced by the following properties:
 - [`Span/supplier`](json,network-schema.json,/$defs/Span,supplier)
 - [`Phase/funders`](json,network-schema.json,/$defs/Phase,funders)
 
+Additional properties are not permitted within `OrganisationReference` objects.
+
 Each `OrganisationReference` has the following properties:
 
 ::::{tab-set}
@@ -477,6 +479,8 @@ This sub-schema is referenced by the following properties:
 - [`Node/phase`](json,network-schema.json,/$defs/Node,phase)
 - [`Span/phase`](json,network-schema.json,/$defs/Span,phase)
 - [`Contract/relatedPhases`](json,network-schema.json,/$defs/Contract,relatedPhases)
+
+Additional properties are not permitted within `PhaseReference` objects.
 
 Each `PhaseReference` has the following properties:
 


### PR DESCRIPTION
Explain that additional properties are not permitted with OrganisationReference and PhaseReference objects.

**Related issues**

* #187 

**Description**

The schema change was made in #328, but I omitted to update the text on the reference page. 

**Merge checklist**

<!-- Complete the checklist before requesting a review. -->

- [x] Update the changelog ([style guide](https://ofds-standard-development-handbook.readthedocs.io/en/latest/style/changelog_style_guide.html))