### PR TITLE
docs/reference/data_model.md: Fix typo in directive options

### DIFF
--- a/docs/reference/data_model.md
+++ b/docs/reference/data_model.md
@@ -90,7 +90,7 @@ Some attributes refer to [codelists](codelists.md) to limit and standardise the 
 :animate: fade-in-slide-down
 :chevron: down-up
 :icon: book
-name: phase-description
+:name: phase-description
 ```{jsoninclude-quote} ../../_readthedocs/html/network-schema.json
 :jsonpointer: /$defs/Phase/description
 ```


### PR DESCRIPTION
Fixing an issue that I spotted:

<img width="889" height="291" alt="image" src="https://github.com/user-attachments/assets/6c82373e-fc1c-4c14-a259-56188fc5314a" />

No changelog entry required.